### PR TITLE
ref: Replace GitHub stats with faster API versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,15 @@
 ![](https://github-readme-activity-graph.vercel.app/graph?username=mohitkumhar&theme=github-compact&custom_title=Here%20is%20Mohit's%20Contribution&hide_border=true&area=true&color=708090&line=ff69b4&point=dda0dd)
 
 
-| ![](https://github-readme-stats.vercel.app/api?username=mohitkumhar&theme=dark&hide_border=false&include_all_commits=true&count_private=true) | ![](https://github-readme-streak-stats.herokuapp.com/?user=mohitkumhar&theme=dark&hide_border=false) | ![](https://github-readme-stats.vercel.app/api/top-langs/?username=mohitkumhar&theme=dark&hide_border=false&include_all_commits=true&count_private=true&layout=compact) |
-|---|---|---|
+
+![GitHub Stats](https://github-readme-stats-fast.vercel.app/api?username=mohitkumhar&show_icons=true&theme=merko&include_all_commits=true&count_private=true&layout=compact)
+![GitHub Stats](https://github-readme-stats-fast.vercel.app/api/streak?username=mohitkumhar&theme=merk&include_all_commits=true&count_private=true&layout=compacto)
+![GitHub Stats](https://github-readme-stats-fast.vercel.app/api/top-langs/?username=mohitkumhar&layout=compact&theme=merko)
+
+
+<!--
+| ![](https://github-readme-stats.vercel.app/api?username=mohitkumhar&theme=dark&hide_border=false&include_all_commits=true&count_private=true) | ![](https://github-readme-streak-stats.herokuapp.com/?user=mohitkumhar&theme=dark&hide_border=false) | ![](https://github-readme-stats.vercel.app/api/top-langs/?username=mohitkumhar&theme=dark&hide_border=false&include_all_commits=true&count_private=true&layout=compact) -->
+
 
 <br>
 


### PR DESCRIPTION
Updated GitHub stats images to use a faster API and removed old stats section.